### PR TITLE
Optimize lang attribute selectors

### DIFF
--- a/cssselect2/__init__.py
+++ b/cssselect2/__init__.py
@@ -31,6 +31,7 @@ class Matcher(object):
         self.class_selectors = {}
         self.lower_local_name_selectors = {}
         self.namespace_selectors = {}
+        self.lang_attr_selectors = []
         self.other_selectors = []
         self.order = 0
 
@@ -68,6 +69,8 @@ class Matcher(object):
         elif selector.namespace is not None:
             self.namespace_selectors.setdefault(selector.namespace, []) \
                 .append(entry)
+        elif selector.requires_lang_attr:
+            self.lang_attr_selectors.append(entry)
         else:
             self.other_selectors.append(entry)
 
@@ -98,6 +101,10 @@ class Matcher(object):
                 ascii_lower(element.local_name), []))
         relevant_selectors.append(
             self.namespace_selectors.get(element.namespace_url, []))
+
+        if "lang" in element.el.etree_element.attrib:
+            relevant_selectors.append(self.lang_attr_selectors)
+
         relevant_selectors.append(self.other_selectors)
 
         results = [

--- a/cssselect2/__init__.py
+++ b/cssselect2/__init__.py
@@ -102,7 +102,7 @@ class Matcher(object):
         relevant_selectors.append(
             self.namespace_selectors.get(element.namespace_url, []))
 
-        if "lang" in element.el.etree_element.attrib:
+        if 'lang' in element.etree_element.attrib:
             relevant_selectors.append(self.lang_attr_selectors)
 
         relevant_selectors.append(self.other_selectors)

--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -54,6 +54,7 @@ class CompiledSelector(object):
         self.local_name = None
         self.lower_local_name = None
         self.namespace = None
+        self.requires_lang_attr = False
 
         node = parsed_selector.parsed_tree
         if isinstance(node, parser.CombinedSelector):
@@ -68,6 +69,9 @@ class CompiledSelector(object):
                 self.lower_local_name = simple_selector.lower_local_name
             elif isinstance(simple_selector, parser.NamespaceSelector):
                 self.namespace = simple_selector.namespace
+            elif isinstance(simple_selector, parser.AttributeSelector) and \
+                    simple_selector.name == "lang":
+                self.requires_lang_attr = True
 
 
 def _compile_node(selector):
@@ -169,7 +173,7 @@ def _compile_node(selector):
                        % (selector.lower_name, selector.name))
             value = selector.value
             if selector.operator is None:
-                return 'el.etree_element.get(%s) is not None' % key
+                return '%s in el.etree_element.attrib' % key
             elif selector.operator == '=':
                 return 'el.etree_element.get(%s) == %r' % (key, value)
             elif selector.operator == '~=':


### PR DESCRIPTION
Don’t look even look at these 169 selectors:

https://github.com/Kozea/WeasyPrint/blob/6f6b266477b0c8f1b773d480187da06a3473e311/weasyprint/css/html5_ua.css#L22-L191

if the element does not have a `lang` attribute.
The trade-off is spending time on each element to check whether it has that attribute.