### PR TITLE
Use elemene.iter instead of getiterator for Python 3.9 compatibility.

### DIFF
--- a/cssselect2/tests/test_cssselect2.py
+++ b/cssselect2/tests/test_cssselect2.py
@@ -28,7 +28,12 @@ def load_json(filename):
 
 def get_test_document():
     document = etree.parse(resource('content.xhtml'))
-    parent = next(e for e in document.getiterator() if e.get('id') == 'root')
+    if hasattr(document, 'iter'):
+        iterator = document.iter()
+    else:
+        iterator = document.getiterator()
+
+    parent = next(e for e in iterator if e.get('id') == 'root')
 
     # Setup namespace tests
     for id in ('any-namespace', 'no-namespace'):


### PR DESCRIPTION
Fixes #12 