### PR TITLE
Rewrite compiler without eval

### DIFF
--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -1,7 +1,4 @@
-"""Compile CSS4 selectors into boolean evaluator functions, operating on ElementWrapper"""
-
 import re
-from typing import Union
 from urllib.parse import urlparse
 
 from tinycss2.nth import parse_nth
@@ -14,7 +11,7 @@ from .parser import SelectorError
 split_whitespace = re.compile('[^ \t\r\n\f]+').findall
 
 
-def compile_selector_list(input, namespaces=None): #pylint: disable=redefined-builtin
+def compile_selector_list(input, namespaces=None):
     """Compile a (comma-separated) list of selectors.
 
     :param input:
@@ -36,7 +33,7 @@ def compile_selector_list(input, namespaces=None): #pylint: disable=redefined-bu
         for selector in parser.parse(input, namespaces)
     ]
 
-#pylint: disable=comparison-with-callable, too-many-instance-attributes, invalid-name
+
 class CompiledSelector:
     """Abstract representation of a selector."""
     def __init__(self, parsed_selector):
@@ -69,16 +66,16 @@ class CompiledSelector:
                 if simple_selector.name == 'lang':
                     self.requires_lang_attr = True
 
+
 def FALSE(_el):
-    """Always returns 0"""
     return 0
+
+
 def TRUE(_el):
-    """Always returns 1"""
     return 1
 
 
-
-def _compile_combined(selector: parser.CombinedSelector):
+def _compile_combined(selector):
     left_inside = _compile_node(selector.left)
     if left_inside == FALSE:
         return FALSE  # 0 and x == 0
@@ -115,7 +112,8 @@ def _compile_combined(selector: parser.CombinedSelector):
     # Evaluate combinators right to left
     return lambda el: right(el) and left(el)
 
-def _compile_compound(selector: parser.CompoundSelector):
+
+def _compile_compound(selector):
     sub_expressions = [
         expr for expr in map(_compile_node, selector.simple_selectors)
         if expr != TRUE]
@@ -127,7 +125,8 @@ def _compile_compound(selector: parser.CompoundSelector):
         return lambda e: all(expr(e) for expr in sub_expressions)
     return TRUE  # all([]) == True
 
-def _compile_negation(selector: parser.NegationSelector):
+
+def _compile_negation(selector):
     sub_expressions = [
         expr for expr in [
             _compile_node(selector.parsed_tree)
@@ -138,34 +137,36 @@ def _compile_negation(selector: parser.NegationSelector):
     return lambda el: not any(expr(el) for expr in sub_expressions)
 
 
-def _get_subexpr(expression, relative_selector):
-    """Helper function for RelationalSelector"""
-    if relative_selector.combinator == ' ':
-        def check(el):
-            subels = el.iter_subtree()
-            # Skip self (only look at descendants)
-            next(subels)
-            return any(expression(e) for e in subels)
-        return check
-    if relative_selector.combinator == '>':
-        return lambda el: any(expression(e) for e in el.iter_children())
-    if relative_selector.combinator == '+':
-        return lambda el: expression(next(el.iter_next_siblings()))
-    if relative_selector.combinator == '~':
-        return lambda el: any(expression(e) for e in el.iter_next_siblings())
-    raise SelectorError(f"Unknown relational selector '{relative_selector.combinator}'")
-
-def _compile_relational(selector: parser.RelationalSelector):
-    sub_expr = []
+def _compile_relational(selector):
+    sub_expressions = []
 
     for relative_selector in selector.selector_list:
         expression = _compile_node(relative_selector.selector.parsed_tree)
         if expression == FALSE:
             continue
-        sub_expr.append(_get_subexpr(expression, relative_selector))
-    return lambda el: any(expr(el) for expr in sub_expr)
+        elif relative_selector.combinator == ' ':
+            def sub_expression(el):
+                sub_elements = el.iter_subtree()
+                # Skip self (only look at descendants)
+                next(sub_elements)
+                return any(expression(e) for e in sub_elements)
+        elif relative_selector.combinator == '>':
+            def sub_expression(el):
+                return any(expression(e) for e in el.iter_children())
+        elif relative_selector.combinator == '+':
+            def sub_expression(el):
+                return expression(next(el.iter_next_siblings()))
+        elif relative_selector.combinator == '~':
+            def sub_expression(el):
+                return any(expression(e) for e in el.iter_next_siblings())
+        else:
+            raise SelectorError(
+                'Unknown relational selector', {relative_selector.combinator})
+        sub_expressions.append(sub_expression)
+    return lambda el: any(expr(el) for expr in sub_expressions)
 
-def _compile_any(selector: Union[parser.MatchesAnySelector, parser.SpecificityAdjustmentSelector]):
+
+def _compile_any(selector):
     sub_expressions = [
         expr for expr in [
             _compile_node(selector.parsed_tree)
@@ -175,20 +176,26 @@ def _compile_any(selector: Union[parser.MatchesAnySelector, parser.SpecificityAd
         return FALSE
     return lambda el: any(expr(el) for expr in sub_expressions)
 
+
 def _compile_local_name(selector: parser.LocalNameSelector):
     if selector.lower_local_name == selector.local_name:
         return lambda el: el.local_name == selector.local_name
     return lambda el: el.local_name == (
-        selector.lower_local_name if el.in_html_document else selector.local_name)
+        selector.lower_local_name if el.in_html_document
+        else selector.local_name)
+
 
 def _compile_namespace(selector: parser.NamespaceSelector):
     return lambda el: el.namespace_url == selector.namespace
 
+
 def _compile_class(selector: parser.ClassSelector):
     return lambda el: selector.class_name in el.classes
 
+
 def _compile_id(selector: parser.IDSelector):
     return lambda el: el.id == selector.ident
+
 
 def _compile_attribute(selector: parser.AttributeSelector):
     if selector.namespace is not None:
@@ -197,21 +204,22 @@ def _compile_attribute(selector: parser.AttributeSelector):
                 def key_func(_el):
                     return f'{{{selector.namespace}}}{selector.name}'
             else:
-                lower = f'{{{selector.namespace}}}{selector.lower_name}'
-                name = f'{{{selector.namespace}}}{selector.name}'
                 def key_func(el):
                     return (lower if el.in_html_document else name)
+                lower = f'{{{selector.namespace}}}{selector.lower_name}'
+                name = f'{{{selector.namespace}}}{selector.name}'
         else:
             if selector.name == selector.lower_name:
                 def key_func(_el):
                     return selector.name
             else:
-                lower, name = selector.lower_name, selector.name
                 def key_func(el):
                     return lower if el.in_html_document else name
+                lower, name = selector.lower_name, selector.name
         value = selector.value
         if selector.case_sensitive is False:
             value = value.lower()
+
             def attribute_value(el):
                 return el.etree_element.get(key_func(el), "").lower()
         else:
@@ -220,54 +228,68 @@ def _compile_attribute(selector: parser.AttributeSelector):
         if selector.operator is None:
             return lambda el: key_func(el) in el.etree_element.attrib
         if selector.operator == '=':
-            return lambda el: (key_func(el) in el.etree_element.attrib and
-                                attribute_value(el) == value)
+            return lambda el: (
+                key_func(el) in el.etree_element.attrib and
+                attribute_value(el) == value)
         if selector.operator == '~=':
-            return (FALSE if len(value.split()) != 1 or value.strip() != value
-                    else lambda el: value in split_whitespace(attribute_value(el)))
+            return (
+                FALSE if len(value.split()) != 1 or value.strip() != value
+                else lambda el: value in split_whitespace(attribute_value(el)))
         if selector.operator == '|=':
-            return lambda el: (key_func(el) in el.etree_element.attrib and
-                                (attribute_value(el) == value or
-                                attribute_value(el).startswith(value + "-") ))
+            return lambda el: (
+                key_func(el) in el.etree_element.attrib and (
+                    attribute_value(el) == value or
+                    attribute_value(el).startswith(value + "-")))
         if selector.operator == '^=':
             if value:
                 return lambda el:  attribute_value(el).startswith(value)
             return FALSE
         if selector.operator == '$=':
-            return (lambda el:  attribute_value(el).endswith(value)) if value else FALSE
+            return (
+                (lambda el:  attribute_value(el).endswith(value))
+                if value else FALSE)
         if selector.operator == '*=':
-            return (lambda el:  value in attribute_value(el)) if value else FALSE
+            return (
+                (lambda el:  value in attribute_value(el)) if value else FALSE)
         raise SelectorError('Unknown attribute operator', selector.operator)
     # In any namespace
     raise NotImplementedError  # TODO
 
+
 def _compile_pseudoclass(selector: parser.PseudoClassSelector):
     if selector.name in ('link', 'any-link', 'local-link'):
         def test(el):
-            return (html_tag_eq('a', 'area', 'link')(el) and
-                    el.etree_element.get("href") is not None)
+            return (
+                html_tag_eq('a', 'area', 'link')(el) and
+                el.etree_element.get("href") is not None)
         if selector.name == 'local-link':
-            return lambda el: test(el) and not urlparse(el.etree_element.get("href")).scheme
+            return lambda el: (
+                test(el) and not urlparse(el.etree_element.get("href")).scheme)
         return test
     if selector.name == 'enabled':
         return lambda el: (
-            (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el) and
-                (el.etree_element.get("disabled") is None) and not el.in_disabled_fieldset) or
-            (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el) and
-                el.etree_element.get("disabled") is None) or
-            (html_tag_eq('a', 'area', 'link')(el) and el.etree_element.get("href") is not None))
+            (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el)
+             and (el.etree_element.get("disabled") is None)
+             and not el.in_disabled_fieldset) or
+            (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el)
+             and el.etree_element.get("disabled") is None) or
+            (html_tag_eq('a', 'area', 'link')(el)
+             and el.etree_element.get("href") is not None))
     if selector.name == 'disabled':
         return lambda el: (
-            (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el) and
-                (el.etree_element.get("disabled") is not None or el.in_disabled_fieldset)) or
-            (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el) and
-                el.etree_element.get("disabled") is not None))
+            (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el)
+             and (el.etree_element.get("disabled") is not None
+                  or el.in_disabled_fieldset)) or
+            (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el)
+             and el.etree_element.get("disabled") is not None))
     if selector.name == 'checked':
         return lambda el: (
             (html_tag_eq('input', 'menuitem')(el) and
                 el.etree_element.get("checked") is not None and
-                ascii_lower(el.etree_element.get("type", "")) in ("checkbox", "radio")) or
-            (html_tag_eq('option')(el) and el.etree_element.get("selected") is not None))
+                ascii_lower(el.etree_element.get("type", ""))
+             in ("checkbox", "radio")) or
+            (html_tag_eq('option')(el) and el.etree_element.get("selected")
+             is not None))
     if selector.name in (
             'visited', 'hover', 'active', 'focus', 'focus-within',
             'focus-visible', 'target', 'target-within', 'current', 'past',
@@ -283,21 +305,25 @@ def _compile_pseudoclass(selector: parser.PseudoClassSelector):
     if selector.name == 'last-child':
         return lambda el: el.index + 1 == len(el.etree_siblings)
     if selector.name == 'first-of-type':
-        return lambda el: all(s.tag != el.etree_element.tag
-                                for s in el.etree_siblings[:el.index])
+        return lambda el: all(
+            s.tag != el.etree_element.tag
+            for s in el.etree_siblings[:el.index])
     if selector.name == 'last-of-type':
-        return lambda el: all(s.tag != el.etree_element.tag
-                                for s in el.etree_siblings[el.index + 1:])
+        return lambda el: all(
+            s.tag != el.etree_element.tag
+            for s in el.etree_siblings[el.index + 1:])
     if selector.name == 'only-child':
         return lambda el: len(el.etree_siblings) == 1
     if selector.name == 'only-of-type':
-        return lambda el: all(s.tag != el.etree_element.tag or i == el.index
-                                for i, s in enumerate(el.etree_siblings))
+        return lambda el: all(
+            s.tag != el.etree_element.tag or i == el.index
+            for i, s in enumerate(el.etree_siblings))
     if selector.name == 'empty':
         return lambda el: not (el.etree_children or el.etree_element.text)
     raise SelectorError('Unknown pseudo-class', selector.name)
 
-def _compile_lang(selector: parser.FunctionalPseudoClassSelector):
+
+def _compile_lang(selector):
     langs = []
     tokens = [
         token for token in selector.arguments
@@ -314,10 +340,11 @@ def _compile_lang(selector: parser.FunctionalPseudoClassSelector):
             token = tokens.pop(0)
             if token.type != 'ident' and token.value != ',':
                 raise SelectorError('Invalid arguments for :lang()')
-    return lambda el: any(el.lang == lang or el.lang.startswith(lang + "-")
-                            for lang in langs)
+    return lambda el: any(
+        el.lang == lang or el.lang.startswith(lang + "-") for lang in langs)
 
-def _compile_functional_pseudoclass(selector: parser.FunctionalPseudoClassSelector):
+
+def _compile_functional_pseudoclass(selector):
     if selector.name == 'lang':
         return _compile_lang(selector)
     nth = []
@@ -331,27 +358,35 @@ def _compile_functional_pseudoclass(selector: parser.FunctionalPseudoClassSelect
         current_list.append(argument)
 
     if selector_list:
-        compiled = tuple(_compile_node(selector.parsed_tree)
-            for selector in parser.parse(selector_list))
         def test(el):
             return all(expr(el) for expr in compiled)
+
+        compiled = tuple(
+            _compile_node(selector.parsed_tree)
+            for selector in parser.parse(selector_list))
         if selector.name == 'nth-child':
             def count(el):
                 return sum(1 for e in el.previous_siblings if test(e))
         elif selector.name == 'nth-last-child':
             def count(el):
-                return sum(1 for e in tuple(el.iter_siblings())[el.index + 1:] if test(e))
+                return sum(
+                    1 for e in tuple(el.iter_siblings())[el.index + 1:]
+                    if test(e))
         elif selector.name == 'nth-of-type':
             def count(el):
-                return (sum(1 for s in (e for e in el.previous_siblings if test(e))
-                            if s.etree_element.tag == el.etree_element.tag))
+                return sum(
+                    1 for s in (e for e in el.previous_siblings if test(e))
+                    if s.etree_element.tag == el.etree_element.tag)
         elif selector.name == 'nth-last-of-type':
             def count(el):
-                return (sum(1 for s in (e for e in tuple(el.iter_siblings())[el.index + 1:]
-                                        if test(e))
-                            if s.etree_element.tag == el.etree_element.tag))
+                return sum(
+                    1 for s in (
+                        e for e in tuple(el.iter_siblings())[el.index + 1:]
+                        if test(e))
+                    if s.etree_element.tag == el.etree_element.tag)
         else:
             raise SelectorError('Unknown pseudo-class', selector.name)
+
         def count_func(el):
             return count(el) if test(el) else float("nan")
     else:
@@ -366,11 +401,14 @@ def _compile_functional_pseudoclass(selector: parser.FunctionalPseudoClassSelect
                 return len(el.etree_siblings) - el.index - 1
         elif selector.name == 'nth-of-type':
             def count_func(el):
-                return sum(1 for s in el.etree_siblings[:el.index] if s.tag == el.etree_element.tag)
+                return sum(
+                    1 for s in el.etree_siblings[:el.index]
+                    if s.tag == el.etree_element.tag)
         elif selector.name == 'nth-last-of-type':
             def count_func(el):
-                return sum(1 for s in el.etree_siblings[el.index + 1:]
-                            if s.tag == el.etree_element.tag)
+                return sum(
+                    1 for s in el.etree_siblings[el.index + 1:]
+                    if s.tag == el.etree_element.tag)
         else:
             raise SelectorError('Unknown pseudo-class', selector.name)
 
@@ -378,6 +416,7 @@ def _compile_functional_pseudoclass(selector: parser.FunctionalPseudoClassSelect
     if result is None:
         raise SelectorError(
             f'Invalid arguments for :{selector.name}()')
+
     a, b = result
     # x is the number of siblings before/after the element
     # Matches if a positive or zero integer n exists so that:
@@ -387,27 +426,30 @@ def _compile_functional_pseudoclass(selector: parser.FunctionalPseudoClassSelect
     if a == 0:
         # x = B
         return lambda el: count_func(el) == B
+
     # n = (x - B) / a
     def evaluator(el):
         n, r = divmod(count_func(el) - B, a)
         return r == 0 and n >= 0
     return evaluator
 
+
 _func_map = {
-    parser.CombinedSelector : _compile_combined,
-    parser.CompoundSelector : _compile_compound,
-    parser.NegationSelector : _compile_negation,
-    parser.RelationalSelector : _compile_relational,
-    parser.MatchesAnySelector : _compile_any,
-    parser.SpecificityAdjustmentSelector : _compile_any,
-    parser.LocalNameSelector : _compile_local_name,
-    parser.NamespaceSelector : _compile_namespace,
-    parser.ClassSelector : _compile_class,
-    parser.IDSelector : _compile_id,
-    parser.AttributeSelector : _compile_attribute,
-    parser.PseudoClassSelector : _compile_pseudoclass,
-    parser.FunctionalPseudoClassSelector : _compile_functional_pseudoclass
+    parser.CombinedSelector: _compile_combined,
+    parser.CompoundSelector: _compile_compound,
+    parser.NegationSelector: _compile_negation,
+    parser.RelationalSelector: _compile_relational,
+    parser.MatchesAnySelector: _compile_any,
+    parser.SpecificityAdjustmentSelector: _compile_any,
+    parser.LocalNameSelector: _compile_local_name,
+    parser.NamespaceSelector: _compile_namespace,
+    parser.ClassSelector: _compile_class,
+    parser.IDSelector: _compile_id,
+    parser.AttributeSelector: _compile_attribute,
+    parser.PseudoClassSelector: _compile_pseudoclass,
+    parser.FunctionalPseudoClassSelector: _compile_functional_pseudoclass,
 }
+
 
 def _compile_node(selector):
     """Return a boolean expression, as a callable.
@@ -422,12 +464,15 @@ def _compile_node(selector):
     except KeyError as e:
         raise TypeError(type(selector), selector) from e
 
+
 def html_tag_eq(*local_names):
     """Generate expression testing equality with HTML local names."""
     if len(local_names) == 1:
         tag = '{http://www.w3.org/1999/xhtml}' + local_names[0]
-        return lambda el: ((el.local_name == local_names[0])
-                           if el.in_html_document else (el.etree_element.tag == tag))
+        return lambda el: (
+            (el.local_name == local_names[0])
+            if el.in_html_document else (el.etree_element.tag == tag))
     tags = ('{http://www.w3.org/1999/xhtml}' + n for n in local_names)
-    return lambda el: ((el.local_name in local_names)
-                        if el.in_html_document else (el.etree_element.tag in tags))
+    return lambda el: (
+        (el.local_name in local_names)
+        if el.in_html_document else (el.etree_element.tag in tags))

--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -139,7 +139,6 @@ def _compile_negation(selector):
 
 def _compile_relational(selector):
     sub_expressions = []
-
     for relative_selector in selector.selector_list:
         expression = _compile_node(relative_selector.selector.parsed_tree)
         if expression == FALSE:
@@ -177,7 +176,7 @@ def _compile_any(selector):
     return lambda el: any(expr(el) for expr in sub_expressions)
 
 
-def _compile_local_name(selector: parser.LocalNameSelector):
+def _compile_local_name(selector):
     if selector.lower_local_name == selector.local_name:
         return lambda el: el.local_name == selector.local_name
     return lambda el: el.local_name == (
@@ -185,19 +184,19 @@ def _compile_local_name(selector: parser.LocalNameSelector):
         else selector.local_name)
 
 
-def _compile_namespace(selector: parser.NamespaceSelector):
+def _compile_namespace(selector):
     return lambda el: el.namespace_url == selector.namespace
 
 
-def _compile_class(selector: parser.ClassSelector):
+def _compile_class(selector):
     return lambda el: selector.class_name in el.classes
 
 
-def _compile_id(selector: parser.IDSelector):
+def _compile_id(selector):
     return lambda el: el.id == selector.ident
 
 
-def _compile_attribute(selector: parser.AttributeSelector):
+def _compile_attribute(selector):
     if selector.namespace is not None:
         if selector.namespace:
             if selector.name == selector.lower_name:
@@ -256,7 +255,7 @@ def _compile_attribute(selector: parser.AttributeSelector):
     raise NotImplementedError  # TODO
 
 
-def _compile_pseudoclass(selector: parser.PseudoClassSelector):
+def _compile_pseudoclass(selector):
     if selector.name in ('link', 'any-link', 'local-link'):
         def test(el):
             return (

--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -220,10 +220,10 @@ def _compile_attribute(selector):
             value = value.lower()
 
             def attribute_value(el):
-                return el.etree_element.get(key_func(el), "").lower()
+                return el.etree_element.get(key_func(el), '').lower()
         else:
             def attribute_value(el):
-                return el.etree_element.get(key_func(el), "")
+                return el.etree_element.get(key_func(el), '')
         if selector.operator is None:
             return lambda el: key_func(el) in el.etree_element.attrib
         if selector.operator == '=':
@@ -238,7 +238,7 @@ def _compile_attribute(selector):
             return lambda el: (
                 key_func(el) in el.etree_element.attrib and (
                     attribute_value(el) == value or
-                    attribute_value(el).startswith(value + "-")))
+                    attribute_value(el).startswith(value + '-')))
         if selector.operator == '^=':
             if value:
                 return lambda el:  attribute_value(el).startswith(value)
@@ -260,34 +260,34 @@ def _compile_pseudoclass(selector):
         def test(el):
             return (
                 html_tag_eq('a', 'area', 'link')(el) and
-                el.etree_element.get("href") is not None)
+                el.etree_element.get('href') is not None)
         if selector.name == 'local-link':
             return lambda el: (
-                test(el) and not urlparse(el.etree_element.get("href")).scheme)
+                test(el) and not urlparse(el.etree_element.get('href')).scheme)
         return test
     if selector.name == 'enabled':
         return lambda el: (
             (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el)
-             and (el.etree_element.get("disabled") is None)
+             and (el.etree_element.get('disabled') is None)
              and not el.in_disabled_fieldset) or
             (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el)
-             and el.etree_element.get("disabled") is None) or
+             and el.etree_element.get('disabled') is None) or
             (html_tag_eq('a', 'area', 'link')(el)
-             and el.etree_element.get("href") is not None))
+             and el.etree_element.get('href') is not None))
     if selector.name == 'disabled':
         return lambda el: (
             (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el)
-             and (el.etree_element.get("disabled") is not None
+             and (el.etree_element.get('disabled') is not None
                   or el.in_disabled_fieldset)) or
             (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el)
-             and el.etree_element.get("disabled") is not None))
+             and el.etree_element.get('disabled') is not None))
     if selector.name == 'checked':
         return lambda el: (
             (html_tag_eq('input', 'menuitem')(el) and
-                el.etree_element.get("checked") is not None and
-                ascii_lower(el.etree_element.get("type", ""))
-             in ("checkbox", "radio")) or
-            (html_tag_eq('option')(el) and el.etree_element.get("selected")
+                el.etree_element.get('checked') is not None and
+                ascii_lower(el.etree_element.get('type', ''))
+             in ('checkbox', 'radio')) or
+            (html_tag_eq('option')(el) and el.etree_element.get('selected')
              is not None))
     if selector.name in (
             'visited', 'hover', 'active', 'focus', 'focus-within',
@@ -340,7 +340,7 @@ def _compile_lang(selector):
             if token.type != 'ident' and token.value != ',':
                 raise SelectorError('Invalid arguments for :lang()')
     return lambda el: any(
-        el.lang == lang or el.lang.startswith(lang + "-") for lang in langs)
+        el.lang == lang or el.lang.startswith(lang + '-') for lang in langs)
 
 
 def _compile_functional_pseudoclass(selector):
@@ -387,7 +387,7 @@ def _compile_functional_pseudoclass(selector):
             raise SelectorError('Unknown pseudo-class', selector.name)
 
         def count_func(el):
-            return count(el) if test(el) else float("nan")
+            return count(el) if test(el) else float('nan')
     else:
         if current_list is selector_list:
             raise SelectorError(
@@ -471,7 +471,7 @@ def html_tag_eq(*local_names):
         return lambda el: (
             (el.local_name == local_names[0])
             if el.in_html_document else (el.etree_element.tag == tag))
-    tags = ('{http://www.w3.org/1999/xhtml}' + n for n in local_names)
+    tags = ('{http://www.w3.org/1999/xhtml}' + name for name in local_names)
     return lambda el: (
         (el.local_name in local_names)
         if el.in_html_document else (el.etree_element.tag in tags))

--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -30,8 +30,7 @@ def compile_selector_list(input, namespaces=None):
     """
     return [
         CompiledSelector(selector)
-        for selector in parser.parse(input, namespaces)
-    ]
+        for selector in parser.parse(input, namespaces)]
 
 
 class CompiledSelector:
@@ -203,24 +202,25 @@ def _compile_attribute(selector):
                 def key_func(_el):
                     return f'{{{selector.namespace}}}{selector.name}'
             else:
-                def key_func(el):
-                    return (lower if el.in_html_document else name)
                 lower = f'{{{selector.namespace}}}{selector.lower_name}'
                 name = f'{{{selector.namespace}}}{selector.name}'
+
+                def key_func(el):
+                    return lower if el.in_html_document else name
         else:
             if selector.name == selector.lower_name:
                 def key_func(_el):
                     return selector.name
             else:
+                lower, name = selector.lower_name, selector.name
+
                 def key_func(el):
                     return lower if el.in_html_document else name
-                lower, name = selector.lower_name, selector.name
         value = selector.value
         if selector.case_sensitive is False:
-            value = value.lower()
-
             def attribute_value(el):
                 return el.etree_element.get(key_func(el), '').lower()
+            value = value.lower()
         else:
             def attribute_value(el):
                 return el.etree_element.get(key_func(el), '')
@@ -241,15 +241,15 @@ def _compile_attribute(selector):
                     attribute_value(el).startswith(value + '-')))
         if selector.operator == '^=':
             if value:
-                return lambda el:  attribute_value(el).startswith(value)
+                return lambda el: attribute_value(el).startswith(value)
             return FALSE
         if selector.operator == '$=':
             return (
-                (lambda el:  attribute_value(el).endswith(value))
+                (lambda el: attribute_value(el).endswith(value))
                 if value else FALSE)
         if selector.operator == '*=':
             return (
-                (lambda el:  value in attribute_value(el)) if value else FALSE)
+                (lambda el: value in attribute_value(el)) if value else FALSE)
         raise SelectorError('Unknown attribute operator', selector.operator)
     # In any namespace
     raise NotImplementedError  # TODO
@@ -467,11 +467,11 @@ def _compile_node(selector):
 def html_tag_eq(*local_names):
     """Generate expression testing equality with HTML local names."""
     if len(local_names) == 1:
-        tag = '{http://www.w3.org/1999/xhtml}' + local_names[0]
+        tag = f'{{http://www.w3.org/1999/xhtml}}{local_names[0]}'
         return lambda el: (
             (el.local_name == local_names[0])
             if el.in_html_document else (el.etree_element.tag == tag))
-    tags = ('{http://www.w3.org/1999/xhtml}' + name for name in local_names)
+    tags = (f'{{http://www.w3.org/1999/xhtml}}{name}' for name in local_names)
     return lambda el: (
         (el.local_name in local_names)
         if el.in_html_document else (el.etree_element.tag in tags))

--- a/cssselect2/compiler.py
+++ b/cssselect2/compiler.py
@@ -1,4 +1,7 @@
+"""Compile CSS4 selectors into boolean evaluator functions, operating on ElementWrapper"""
+
 import re
+from typing import Union
 from urllib.parse import urlparse
 
 from tinycss2.nth import parse_nth
@@ -11,7 +14,7 @@ from .parser import SelectorError
 split_whitespace = re.compile('[^ \t\r\n\f]+').findall
 
 
-def compile_selector_list(input, namespaces=None):
+def compile_selector_list(input, namespaces=None): #pylint: disable=redefined-builtin
     """Compile a (comma-separated) list of selectors.
 
     :param input:
@@ -33,18 +36,13 @@ def compile_selector_list(input, namespaces=None):
         for selector in parser.parse(input, namespaces)
     ]
 
-
+#pylint: disable=comparison-with-callable, too-many-instance-attributes, invalid-name
 class CompiledSelector:
     """Abstract representation of a selector."""
     def __init__(self, parsed_selector):
         source = _compile_node(parsed_selector.parsed_tree)
-        self.never_matches = source == '0'
-        eval_globals = {
-            'split_whitespace': split_whitespace,
-            'ascii_lower': ascii_lower,
-            'urlparse': urlparse,
-        }
-        self.test = eval('lambda el: ' + source, eval_globals, {})
+        self.never_matches = source == FALSE
+        self.test = source
         self.specificity = parsed_selector.specificity
         self.pseudo_element = parsed_selector.pseudo_element
         self.id = None
@@ -71,358 +69,365 @@ class CompiledSelector:
                 if simple_selector.name == 'lang':
                     self.requires_lang_attr = True
 
+def FALSE(_el):
+    """Always returns 0"""
+    return 0
+def TRUE(_el):
+    """Always returns 1"""
+    return 1
+
+
+
+def _compile_combined(selector: parser.CombinedSelector):
+    left_inside = _compile_node(selector.left)
+    if left_inside == FALSE:
+        return FALSE  # 0 and x == 0
+    if left_inside == TRUE:
+        # 1 and x == x, but the element matching 1 still needs to exist.
+        if selector.combinator in (' ', '>'):
+            def left(el):
+                return el.parent is not None
+        elif selector.combinator in ('~', '+'):
+            def left(el):
+                return el.previous is not None
+        else:
+            raise SelectorError('Unknown combinator', selector.combinator)
+    elif selector.combinator == ' ':
+        def left(el):
+            return any((left_inside(e)) for e in el.ancestors)
+    elif selector.combinator == '>':
+        def left(el):
+            return el.parent is not None and left_inside(el.parent)
+    elif selector.combinator == '+':
+        def left(el):
+            return el.previous is not None and left_inside(el.previous)
+    elif selector.combinator == '~':
+        def left(el):
+            return any((left_inside(e)) for e in el.previous_siblings)
+    else:
+        raise SelectorError('Unknown combinator', selector.combinator)
+
+    right = _compile_node(selector.right)
+    if right == FALSE:
+        return FALSE  # 0 and x == 0
+    if right == TRUE:
+        return left  # 1 and x == x
+    # Evaluate combinators right to left
+    return lambda el: right(el) and left(el)
+
+def _compile_compound(selector: parser.CompoundSelector):
+    sub_expressions = [
+        expr for expr in map(_compile_node, selector.simple_selectors)
+        if expr != TRUE]
+    if len(sub_expressions) == 1:
+        return sub_expressions[0]
+    if FALSE in sub_expressions:
+        return FALSE
+    if sub_expressions:
+        return lambda e: all(expr(e) for expr in sub_expressions)
+    return TRUE  # all([]) == True
+
+def _compile_negation(selector: parser.NegationSelector):
+    sub_expressions = [
+        expr for expr in [
+            _compile_node(selector.parsed_tree)
+            for selector in selector.selector_list]
+        if expr != TRUE]
+    if not sub_expressions:
+        return FALSE
+    return lambda el: not any(expr(el) for expr in sub_expressions)
+
+
+def _get_subexpr(expression, relative_selector):
+    """Helper function for RelationalSelector"""
+    if relative_selector.combinator == ' ':
+        def check(el):
+            subels = el.iter_subtree()
+            # Skip self (only look at descendants)
+            next(subels)
+            return any(expression(e) for e in subels)
+        return check
+    if relative_selector.combinator == '>':
+        return lambda el: any(expression(e) for e in el.iter_children())
+    if relative_selector.combinator == '+':
+        return lambda el: expression(next(el.iter_next_siblings()))
+    if relative_selector.combinator == '~':
+        return lambda el: any(expression(e) for e in el.iter_next_siblings())
+    raise SelectorError(f"Unknown relational selector '{relative_selector.combinator}'")
+
+def _compile_relational(selector: parser.RelationalSelector):
+    sub_expr = []
+
+    for relative_selector in selector.selector_list:
+        expression = _compile_node(relative_selector.selector.parsed_tree)
+        if expression == FALSE:
+            continue
+        sub_expr.append(_get_subexpr(expression, relative_selector))
+    return lambda el: any(expr(el) for expr in sub_expr)
+
+def _compile_any(selector: Union[parser.MatchesAnySelector, parser.SpecificityAdjustmentSelector]):
+    sub_expressions = [
+        expr for expr in [
+            _compile_node(selector.parsed_tree)
+            for selector in selector.selector_list]
+        if expr != FALSE]
+    if not sub_expressions:
+        return FALSE
+    return lambda el: any(expr(el) for expr in sub_expressions)
+
+def _compile_local_name(selector: parser.LocalNameSelector):
+    if selector.lower_local_name == selector.local_name:
+        return lambda el: el.local_name == selector.local_name
+    return lambda el: el.local_name == (
+        selector.lower_local_name if el.in_html_document else selector.local_name)
+
+def _compile_namespace(selector: parser.NamespaceSelector):
+    return lambda el: el.namespace_url == selector.namespace
+
+def _compile_class(selector: parser.ClassSelector):
+    return lambda el: selector.class_name in el.classes
+
+def _compile_id(selector: parser.IDSelector):
+    return lambda el: el.id == selector.ident
+
+def _compile_attribute(selector: parser.AttributeSelector):
+    if selector.namespace is not None:
+        if selector.namespace:
+            if selector.name == selector.lower_name:
+                def key_func(_el):
+                    return f'{{{selector.namespace}}}{selector.name}'
+            else:
+                lower = f'{{{selector.namespace}}}{selector.lower_name}'
+                name = f'{{{selector.namespace}}}{selector.name}'
+                def key_func(el):
+                    return (lower if el.in_html_document else name)
+        else:
+            if selector.name == selector.lower_name:
+                def key_func(_el):
+                    return selector.name
+            else:
+                lower, name = selector.lower_name, selector.name
+                def key_func(el):
+                    return lower if el.in_html_document else name
+        value = selector.value
+        if selector.case_sensitive is False:
+            value = value.lower()
+            def attribute_value(el):
+                return el.etree_element.get(key_func(el), "").lower()
+        else:
+            def attribute_value(el):
+                return el.etree_element.get(key_func(el), "")
+        if selector.operator is None:
+            return lambda el: key_func(el) in el.etree_element.attrib
+        if selector.operator == '=':
+            return lambda el: (key_func(el) in el.etree_element.attrib and
+                                attribute_value(el) == value)
+        if selector.operator == '~=':
+            return (FALSE if len(value.split()) != 1 or value.strip() != value
+                    else lambda el: value in split_whitespace(attribute_value(el)))
+        if selector.operator == '|=':
+            return lambda el: (key_func(el) in el.etree_element.attrib and
+                                (attribute_value(el) == value or
+                                attribute_value(el).startswith(value + "-") ))
+        if selector.operator == '^=':
+            if value:
+                return lambda el:  attribute_value(el).startswith(value)
+            return FALSE
+        if selector.operator == '$=':
+            return (lambda el:  attribute_value(el).endswith(value)) if value else FALSE
+        if selector.operator == '*=':
+            return (lambda el:  value in attribute_value(el)) if value else FALSE
+        raise SelectorError('Unknown attribute operator', selector.operator)
+    # In any namespace
+    raise NotImplementedError  # TODO
+
+def _compile_pseudoclass(selector: parser.PseudoClassSelector):
+    if selector.name in ('link', 'any-link', 'local-link'):
+        def test(el):
+            return (html_tag_eq('a', 'area', 'link')(el) and
+                    el.etree_element.get("href") is not None)
+        if selector.name == 'local-link':
+            return lambda el: test(el) and not urlparse(el.etree_element.get("href")).scheme
+        return test
+    if selector.name == 'enabled':
+        return lambda el: (
+            (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el) and
+                (el.etree_element.get("disabled") is None) and not el.in_disabled_fieldset) or
+            (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el) and
+                el.etree_element.get("disabled") is None) or
+            (html_tag_eq('a', 'area', 'link')(el) and el.etree_element.get("href") is not None))
+    if selector.name == 'disabled':
+        return lambda el: (
+            (html_tag_eq('button', 'input', 'select', 'textarea', 'option')(el) and
+                (el.etree_element.get("disabled") is not None or el.in_disabled_fieldset)) or
+            (html_tag_eq('optgroup', 'menuitem', 'fieldset')(el) and
+                el.etree_element.get("disabled") is not None))
+    if selector.name == 'checked':
+        return lambda el: (
+            (html_tag_eq('input', 'menuitem')(el) and
+                el.etree_element.get("checked") is not None and
+                ascii_lower(el.etree_element.get("type", "")) in ("checkbox", "radio")) or
+            (html_tag_eq('option')(el) and el.etree_element.get("selected") is not None))
+    if selector.name in (
+            'visited', 'hover', 'active', 'focus', 'focus-within',
+            'focus-visible', 'target', 'target-within', 'current', 'past',
+            'future', 'playing', 'paused', 'seeking', 'buffering',
+            'stalled', 'muted', 'volume-locked', 'user-valid',
+            'user-invalid'):
+        # Not applicable in a static context: never match.
+        return FALSE
+    if selector.name in ('root', 'scope'):
+        return lambda el: el.parent is None
+    if selector.name == 'first-child':
+        return lambda el: el.index == 0
+    if selector.name == 'last-child':
+        return lambda el: el.index + 1 == len(el.etree_siblings)
+    if selector.name == 'first-of-type':
+        return lambda el: all(s.tag != el.etree_element.tag
+                                for s in el.etree_siblings[:el.index])
+    if selector.name == 'last-of-type':
+        return lambda el: all(s.tag != el.etree_element.tag
+                                for s in el.etree_siblings[el.index + 1:])
+    if selector.name == 'only-child':
+        return lambda el: len(el.etree_siblings) == 1
+    if selector.name == 'only-of-type':
+        return lambda el: all(s.tag != el.etree_element.tag or i == el.index
+                                for i, s in enumerate(el.etree_siblings))
+    if selector.name == 'empty':
+        return lambda el: not (el.etree_children or el.etree_element.text)
+    raise SelectorError('Unknown pseudo-class', selector.name)
+
+def _compile_lang(selector: parser.FunctionalPseudoClassSelector):
+    langs = []
+    tokens = [
+        token for token in selector.arguments
+        if token.type not in ('whitespace', 'comment')]
+    while tokens:
+        token = tokens.pop(0)
+        if token.type == 'ident':
+            langs.append(token.lower_value)
+        elif token.type == 'string':
+            langs.append(ascii_lower(token.value))
+        else:
+            raise SelectorError('Invalid arguments for :lang()')
+        if tokens:
+            token = tokens.pop(0)
+            if token.type != 'ident' and token.value != ',':
+                raise SelectorError('Invalid arguments for :lang()')
+    return lambda el: any(el.lang == lang or el.lang.startswith(lang + "-")
+                            for lang in langs)
+
+def _compile_functional_pseudoclass(selector: parser.FunctionalPseudoClassSelector):
+    if selector.name == 'lang':
+        return _compile_lang(selector)
+    nth = []
+    selector_list = []
+    current_list = nth
+    for argument in selector.arguments:
+        if argument.type == 'ident' and argument.value == 'of':
+            if current_list is nth:
+                current_list = selector_list
+                continue
+        current_list.append(argument)
+
+    if selector_list:
+        compiled = tuple(_compile_node(selector.parsed_tree)
+            for selector in parser.parse(selector_list))
+        def test(el):
+            return all(expr(el) for expr in compiled)
+        if selector.name == 'nth-child':
+            def count(el):
+                return sum(1 for e in el.previous_siblings if test(e))
+        elif selector.name == 'nth-last-child':
+            def count(el):
+                return sum(1 for e in tuple(el.iter_siblings())[el.index + 1:] if test(e))
+        elif selector.name == 'nth-of-type':
+            def count(el):
+                return (sum(1 for s in (e for e in el.previous_siblings if test(e))
+                            if s.etree_element.tag == el.etree_element.tag))
+        elif selector.name == 'nth-last-of-type':
+            def count(el):
+                return (sum(1 for s in (e for e in tuple(el.iter_siblings())[el.index + 1:]
+                                        if test(e))
+                            if s.etree_element.tag == el.etree_element.tag))
+        else:
+            raise SelectorError('Unknown pseudo-class', selector.name)
+        def count_func(el):
+            return count(el) if test(el) else float("nan")
+    else:
+        if current_list is selector_list:
+            raise SelectorError(
+                f'Invalid arguments for :{selector.name}()')
+        if selector.name == 'nth-child':
+            def count_func(el):
+                return el.index
+        elif selector.name == 'nth-last-child':
+            def count_func(el):
+                return len(el.etree_siblings) - el.index - 1
+        elif selector.name == 'nth-of-type':
+            def count_func(el):
+                return sum(1 for s in el.etree_siblings[:el.index] if s.tag == el.etree_element.tag)
+        elif selector.name == 'nth-last-of-type':
+            def count_func(el):
+                return sum(1 for s in el.etree_siblings[el.index + 1:]
+                            if s.tag == el.etree_element.tag)
+        else:
+            raise SelectorError('Unknown pseudo-class', selector.name)
+
+    result = parse_nth(nth)
+    if result is None:
+        raise SelectorError(
+            f'Invalid arguments for :{selector.name}()')
+    a, b = result
+    # x is the number of siblings before/after the element
+    # Matches if a positive or zero integer n exists so that:
+    # x = a*n + b-1
+    # x = a*n + B
+    B = b - 1
+    if a == 0:
+        # x = B
+        return lambda el: count_func(el) == B
+    # n = (x - B) / a
+    def evaluator(el):
+        n, r = divmod(count_func(el) - B, a)
+        return r == 0 and n >= 0
+    return evaluator
+
+_func_map = {
+    parser.CombinedSelector : _compile_combined,
+    parser.CompoundSelector : _compile_compound,
+    parser.NegationSelector : _compile_negation,
+    parser.RelationalSelector : _compile_relational,
+    parser.MatchesAnySelector : _compile_any,
+    parser.SpecificityAdjustmentSelector : _compile_any,
+    parser.LocalNameSelector : _compile_local_name,
+    parser.NamespaceSelector : _compile_namespace,
+    parser.ClassSelector : _compile_class,
+    parser.IDSelector : _compile_id,
+    parser.AttributeSelector : _compile_attribute,
+    parser.PseudoClassSelector : _compile_pseudoclass,
+    parser.FunctionalPseudoClassSelector : _compile_functional_pseudoclass
+}
 
 def _compile_node(selector):
-    """Return a boolean expression, as a Python source string.
+    """Return a boolean expression, as a callable.
 
     When evaluated in a context where the `el` variable is an
     :class:`cssselect2.tree.Element` object, tells whether the element is a
     subject of `selector`.
 
     """
-    # To avoid precedence-related bugs, any sub-expression that is passed
-    # around must be "atomic": add parentheses when the top-level would be
-    # an operator. Bare literals and function calls are fine.
-
-    # 1 and 0 are used for True and False to avoid global lookups.
-
-    if isinstance(selector, parser.CombinedSelector):
-        left_inside = _compile_node(selector.left)
-        if left_inside == '0':
-            return '0'  # 0 and x == 0
-        elif left_inside == '1':
-            # 1 and x == x, but the element matching 1 still needs to exist.
-            if selector.combinator in (' ', '>'):
-                left = 'el.parent is not None'
-            elif selector.combinator in ('~', '+'):
-                left = 'el.previous is not None'
-            else:
-                raise SelectorError('Unknown combinator', selector.combinator)
-        # Rebind the `el` name inside a generator-expressions (in a new scope)
-        # so that 'left_inside' applies to different elements.
-        elif selector.combinator == ' ':
-            left = f'any(({left_inside}) for el in el.ancestors)'
-        elif selector.combinator == '>':
-            left = (
-                f'next(el is not None and ({left_inside}) '
-                'for el in [el.parent])')
-        elif selector.combinator == '+':
-            left = (
-                f'next(el is not None and ({left_inside}) '
-                'for el in [el.previous])')
-        elif selector.combinator == '~':
-            left = f'any(({left_inside}) for el in el.previous_siblings)'
-        else:
-            raise SelectorError('Unknown combinator', selector.combinator)
-
-        right = _compile_node(selector.right)
-        if right == '0':
-            return '0'  # 0 and x == 0
-        elif right == '1':
-            return left  # 1 and x == x
-        else:
-            # Evaluate combinators right to left
-            return f'({right}) and ({left})'
-
-    elif isinstance(selector, parser.CompoundSelector):
-        sub_expressions = [
-            expr for expr in map(_compile_node, selector.simple_selectors)
-            if expr != '1']
-        if len(sub_expressions) == 1:
-            test = sub_expressions[0]
-        elif '0' in sub_expressions:
-            test = '0'
-        elif sub_expressions:
-            test = ' and '.join(f'({e})' for e in sub_expressions)
-        else:
-            test = '1'  # all([]) == True
-        return test
-
-    elif isinstance(selector, parser.NegationSelector):
-        sub_expressions = [
-            expr for expr in [
-                _compile_node(selector.parsed_tree)
-                for selector in selector.selector_list]
-            if expr != '1']
-        if not sub_expressions:
-            return '0'
-        return f'not ({" or ".join(f"({expr})" for expr in sub_expressions)})'
-
-    elif isinstance(selector, parser.RelationalSelector):
-        sub_expressions = []
-        for relative_selector in selector.selector_list:
-            expression = _compile_node(relative_selector.selector.parsed_tree)
-            if expression == '0':
-                continue
-            if relative_selector.combinator == ' ':
-                elements = 'list(el.iter_subtree())[1:]'
-            elif relative_selector.combinator == '>':
-                elements = 'el.iter_children()'
-            elif relative_selector.combinator == '+':
-                elements = 'list(el.iter_next_siblings())[:1]'
-            elif relative_selector.combinator == '~':
-                elements = 'el.iter_next_siblings()'
-            sub_expressions.append(f'(any({expression} for el in {elements}))')
-        return ' or '.join(sub_expressions)
-
-    elif isinstance(selector, (
-            parser.MatchesAnySelector, parser.SpecificityAdjustmentSelector)):
-        sub_expressions = [
-            expr for expr in [
-                _compile_node(selector.parsed_tree)
-                for selector in selector.selector_list]
-            if expr != '0']
-        if not sub_expressions:
-            return '0'
-        return ' or '.join(f'({expr})' for expr in sub_expressions)
-
-    elif isinstance(selector, parser.LocalNameSelector):
-        if selector.lower_local_name == selector.local_name:
-            return f'el.local_name == {selector.local_name!r}'
-        else:
-            return (
-                f'el.local_name == ({selector.lower_local_name!r} '
-                f'if el.in_html_document else {selector.local_name!r})')
-
-    elif isinstance(selector, parser.NamespaceSelector):
-        return f'el.namespace_url == {selector.namespace!r}'
-
-    elif isinstance(selector, parser.ClassSelector):
-        return f'{selector.class_name!r} in el.classes'
-
-    elif isinstance(selector, parser.IDSelector):
-        return f'el.id == {selector.ident!r}'
-
-    elif isinstance(selector, parser.AttributeSelector):
-        if selector.namespace is not None:
-            if selector.namespace:
-                if selector.name == selector.lower_name:
-                    key = repr(f'{{{selector.namespace}}}{selector.name}')
-                else:
-                    lower = f'{{{selector.namespace}}}{selector.lower_name}'
-                    name = f'{{{selector.namespace}}}{selector.name}'
-                    key = f'({lower!r} if el.in_html_document else {name!r})'
-            else:
-                if selector.name == selector.lower_name:
-                    key = repr(selector.name)
-                else:
-                    lower, name = selector.lower_name, selector.name
-                    key = f'({lower!r} if el.in_html_document else {name!r})'
-            value = selector.value
-            attribute_value = f'el.etree_element.get({key}, "")'
-            if selector.case_sensitive is False:
-                value = value.lower()
-                attribute_value += '.lower()'
-            if selector.operator is None:
-                return f'{key} in el.etree_element.attrib'
-            elif selector.operator == '=':
-                return (
-                    f'{key} in el.etree_element.attrib and '
-                    f'{attribute_value} == {value!r}')
-            elif selector.operator == '~=':
-                return (
-                    '0' if len(value.split()) != 1 or value.strip() != value
-                    else f'{value!r} in split_whitespace({attribute_value})')
-            elif selector.operator == '|=':
-                return (
-                    f'{key} in el.etree_element.attrib and '
-                    f'{attribute_value} == {value!r} or '
-                    f'{attribute_value}.startswith({(value + "-")!r})')
-            elif selector.operator == '^=':
-                if value:
-                    return f'{attribute_value}.startswith({value!r})'
-                else:
-                    return '0'
-            elif selector.operator == '$=':
-                return (
-                    f'{attribute_value}.endswith({value!r})' if value else '0')
-            elif selector.operator == '*=':
-                return f'{value!r} in {attribute_value}' if value else '0'
-            else:
-                raise SelectorError(
-                    'Unknown attribute operator', selector.operator)
-        else:  # In any namespace
-            raise NotImplementedError  # TODO
-
-    elif isinstance(selector, parser.PseudoClassSelector):
-        if selector.name in ('link', 'any-link', 'local-link'):
-            test = html_tag_eq('a', 'area', 'link')
-            test += ' and el.etree_element.get("href") is not None '
-            if selector.name == 'local-link':
-                test += 'and not urlparse(el.etree_element.get("href")).scheme'
-            return test
-        elif selector.name == 'enabled':
-            input = html_tag_eq(
-                'button', 'input', 'select', 'textarea', 'option')
-            group = html_tag_eq('optgroup', 'menuitem', 'fieldset')
-            a = html_tag_eq('a', 'area', 'link')
-            return (
-                f'({input} and el.etree_element.get("disabled") is None'
-                '  and not el.in_disabled_fieldset) or'
-                f'({group} and el.etree_element.get("disabled") is None) or '
-                f'({a} and el.etree_element.get("href") is not None)')
-        elif selector.name == 'disabled':
-            input = html_tag_eq(
-                'button', 'input', 'select', 'textarea', 'option')
-            group = html_tag_eq('optgroup', 'menuitem', 'fieldset')
-            return (
-                f'({input} and (el.etree_element.get("disabled") is not None'
-                '  or el.in_disabled_fieldset)) or'
-                f'({group} and el.etree_element.get("disabled") is not None)')
-        elif selector.name == 'checked':
-            input = html_tag_eq('input', 'menuitem')
-            option = html_tag_eq('option')
-            return (
-                f'({input} and el.etree_element.get("checked") is not None and'
-                '  ascii_lower(el.etree_element.get("type", "")) '
-                '  in ("checkbox", "radio")) or ('
-                f'{option} and el.etree_element.get("selected") is not None)')
-        elif selector.name in (
-                'visited', 'hover', 'active', 'focus', 'focus-within',
-                'focus-visible', 'target', 'target-within', 'current', 'past',
-                'future', 'playing', 'paused', 'seeking', 'buffering',
-                'stalled', 'muted', 'volume-locked', 'user-valid',
-                'user-invalid'):
-            # Not applicable in a static context: never match.
-            return '0'
-        elif selector.name in ('root', 'scope'):
-            return 'el.parent is None'
-        elif selector.name == 'first-child':
-            return 'el.index == 0'
-        elif selector.name == 'last-child':
-            return 'el.index + 1 == len(el.etree_siblings)'
-        elif selector.name == 'first-of-type':
-            return (
-                'all(s.tag != el.etree_element.tag'
-                '    for s in el.etree_siblings[:el.index])')
-        elif selector.name == 'last-of-type':
-            return (
-                'all(s.tag != el.etree_element.tag'
-                '    for s in el.etree_siblings[el.index + 1:])')
-        elif selector.name == 'only-child':
-            return 'len(el.etree_siblings) == 1'
-        elif selector.name == 'only-of-type':
-            return (
-                'all(s.tag != el.etree_element.tag or i == el.index'
-                '    for i, s in enumerate(el.etree_siblings))')
-        elif selector.name == 'empty':
-            return 'not (el.etree_children or el.etree_element.text)'
-        else:
-            raise SelectorError('Unknown pseudo-class', selector.name)
-
-    elif isinstance(selector, parser.FunctionalPseudoClassSelector):
-        if selector.name == 'lang':
-            langs = []
-            tokens = [
-                token for token in selector.arguments
-                if token.type not in ('whitespace', 'comment')]
-            while tokens:
-                token = tokens.pop(0)
-                if token.type == 'ident':
-                    langs.append(token.lower_value)
-                elif token.type == 'string':
-                    langs.append(ascii_lower(token.value))
-                else:
-                    raise SelectorError('Invalid arguments for :lang()')
-                if tokens:
-                    token = tokens.pop(0)
-                    if token.type != 'ident' and token.value != ',':
-                        raise SelectorError('Invalid arguments for :lang()')
-            return ' or '.join(
-                f'el.lang == {lang!r} or el.lang.startswith({(lang + "-")!r})'
-                for lang in langs)
-        else:
-            nth = []
-            selector_list = []
-            current_list = nth
-            for argument in selector.arguments:
-                if argument.type == 'ident' and argument.value == 'of':
-                    if current_list is nth:
-                        current_list = selector_list
-                        continue
-                current_list.append(argument)
-
-            if selector_list:
-                test = ' and '.join(
-                    _compile_node(selector.parsed_tree)
-                    for selector in parser.parse(selector_list))
-                if selector.name == 'nth-child':
-                    count = (
-                        f'sum(1 for el in el.previous_siblings if ({test}))')
-                elif selector.name == 'nth-last-child':
-                    count = (
-                        'sum(1 for el in'
-                        '    tuple(el.iter_siblings())[el.index + 1:]'
-                        f'   if ({test}))')
-                elif selector.name == 'nth-of-type':
-                    count = (
-                        'sum(1 for s in ('
-                        '      el for el in el.previous_siblings'
-                        f'     if ({test}))'
-                        '    if s.etree_element.tag == el.etree_element.tag)')
-                elif selector.name == 'nth-last-of-type':
-                    count = (
-                        'sum(1 for s in ('
-                        '      el for el in'
-                        '      tuple(el.iter_siblings())[el.index + 1:]'
-                        f'     if ({test}))'
-                        '    if s.etree_element.tag == el.etree_element.tag)')
-                else:
-                    raise SelectorError('Unknown pseudo-class', selector.name)
-                count += f'if ({test}) else float("nan")'
-            else:
-                if current_list is selector_list:
-                    raise SelectorError(
-                        f'Invalid arguments for :{selector.name}()')
-                if selector.name == 'nth-child':
-                    count = 'el.index'
-                elif selector.name == 'nth-last-child':
-                    count = 'len(el.etree_siblings) - el.index - 1'
-                elif selector.name == 'nth-of-type':
-                    count = (
-                        'sum(1 for s in el.etree_siblings[:el.index]'
-                        '    if s.tag == el.etree_element.tag)')
-                elif selector.name == 'nth-last-of-type':
-                    count = (
-                        'sum(1 for s in el.etree_siblings[el.index + 1:]'
-                        '    if s.tag == el.etree_element.tag)')
-                else:
-                    raise SelectorError('Unknown pseudo-class', selector.name)
-
-            result = parse_nth(nth)
-            if result is None:
-                raise SelectorError(
-                    f'Invalid arguments for :{selector.name}()')
-            a, b = result
-            # x is the number of siblings before/after the element
-            # Matches if a positive or zero integer n exists so that:
-            # x = a*n + b-1
-            # x = a*n + B
-            B = b - 1
-            if a == 0:
-                # x = B
-                return f'({count}) == {B}'
-            else:
-                # n = (x - B) / a
-                return (
-                    'next(r == 0 and n >= 0'
-                    f'    for n, r in [divmod(({count}) - {B}, {a})])')
-
-    else:
-        raise TypeError(type(selector), selector)
-
+    try:
+        return _func_map[selector.__class__](selector)
+    except KeyError as e:
+        raise TypeError(type(selector), selector) from e
 
 def html_tag_eq(*local_names):
     """Generate expression testing equality with HTML local names."""
     if len(local_names) == 1:
         tag = '{http://www.w3.org/1999/xhtml}' + local_names[0]
-        return (
-            f'((el.local_name == {local_names[0]!r}) if el.in_html_document '
-            f'else (el.etree_element.tag == {tag!r}))')
-    else:
-        names = ', '.join(repr(n) for n in local_names)
-        tags = ', '.join(
-            repr('{http://www.w3.org/1999/xhtml}' + n) for n in local_names)
-        return (
-            f'((el.local_name in ({names})) if el.in_html_document '
-            f'else (el.etree_element.tag in ({tags})))')
+        return lambda el: ((el.local_name == local_names[0])
+                           if el.in_html_document else (el.etree_element.tag == tag))
+    tags = ('{http://www.w3.org/1999/xhtml}' + n for n in local_names)
+    return lambda el: ((el.local_name in local_names)
+                        if el.in_html_document else (el.etree_element.tag in tags))


### PR DESCRIPTION
For Inkscape's extension subsystem, I was looking into a faster css evaluation method and came across cssselect2. I like the approach taken here, but I can't use `eval` from a security perspective. Luckily, it's not really necessary as the library can be easily rewritten using lambdas instead.

Most of the change is mechanistic. I've split the long `_compile_node` function into subfunctions that are mapped using a dict.

The unit tests pass unchanged. Speed differences between the two versions are small, usually less than 10% (see also the following diagram).

I know this is a somewhat drastic change, so no hard feelings if this doesn't make it into the library. ~Medium-term I plan to add a second implementation of `CompiledSelector` using a local xpath, where possible. So for `div > p`, we would get `"self::p[parent::div]"` (which is completely different from `cssselect`'s output). Except for the simplest lookups (id, class, type), this is faster than a pure python function. The final `CompiledSelector` would then try to create an XPATH representation, if that bails out, use the existing `_compile_node`, and finally check whether the selector is so simple that `_compile_node` is expected to be faster. But maybe this should be its own library - probably depends on your plan with this project here.~

Edit: After mostly completing this second, xpath-based implementation, there don't seem to be clear speed advantages, those might only exist for objectified etrees which I tested originally. Obviously, and xpath based implementation would not need the construction of the `ElementWrapper` at all, which might be an issue in read-write workloads. So let me know whether you are still interested in it.

Here's the benchmark:

![grafik](https://github.com/Kozea/cssselect2/assets/12698538/c55b160a-7a1b-4e3e-b37c-c49dfb83f122)
